### PR TITLE
Better format for spreadsheet updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ All this repo does is talking to Plaid/Google APIs and writing tokens to your lo
 
 ## Setting up API keys
 
-First things first - rename `.env.sample` to `.env`. Variables in this file will be loaded as environment variables. This file is ignored by Git.
+1. First things first - rename `.env.sample` to `.env`. Variables in this file will be loaded as environment variables. This file is ignored by Git.
+1. Run `npm install` in the repo root.
 
 ### Plaid
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -15,11 +15,21 @@ exports.transformTransactionsToUpdates = function(transactions) {
    *
    * Updates should be in the form of:
    * {
-   *   range: 'A1',
-   *   value: 123
+   *   range: 'A1:B2',
+   *   values: [[1,2],[3,4]]
    * }
+   *
+   * Example: Put each transaction on a line in the spreadsheet.
+   * const updates = transactions.map(function(transaction, i) {
+   *   return {
+   *     range: `A${i + 1}:D${i + 1}`,
+   *     values: [Object.values(transaction)]
+   *   }
+   * });
+   *
    */
 
+  // See example in comment above.
   const updates = []
 
   console.log('DEBUG: updates to be made:')

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -30,7 +30,12 @@ exports.transformTransactionsToUpdates = function(transactions) {
    */
 
   // See example in comment above.
-  const updates = []
+  const updates = transactions.map(function(transaction, i) {
+    return {
+      range: `A${i + 1}:D${i + 1}`,
+      values: [Object.values(transaction)]
+    }
+  });
 
   console.log('DEBUG: updates to be made:')
   console.log(updates)

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -32,10 +32,15 @@ exports.transformTransactionsToUpdates = function(transactions) {
   // See example in comment above.
   const updates = transactions.map(function(transaction, i) {
     return {
-      range: `A${i + 1}:D${i + 1}`,
+      range: `A${i + 2}:D${i + 2}`,
       values: [Object.values(transaction)]
     }
   });
+
+  updates.append({
+      range: `A1:D1`,
+      values: [['Account', 'Name', 'Date', 'Amount']]
+  })
 
   console.log('DEBUG: updates to be made:')
   console.log(updates)

--- a/lib/update.js
+++ b/lib/update.js
@@ -22,7 +22,7 @@ exports.updateSheet = async function(updates) {
       valueInputOption: `USER_ENTERED`,
       data: updates.map(p => ({
         range: p.range,
-        values: [[p.value]]
+        values: p.values
       }))
     }
   }, (err, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1019 @@
+{
+  "name": "build-your-own-mint",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@types/form-data": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "9.6.41",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/node/-/node-9.6.41.tgz",
+      "integrity": "sha1-5XwxUusufsdIxzPOvQwJW0N8XTc="
+    },
+    "@types/request": {
+      "version": "0.0.36",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/request/-/request-0.0.36.tgz",
+      "integrity": "sha1-6EWHD8X6NyQC2fXBn8zEygpa9UM=",
+      "requires": {
+        "@types/form-data": "*",
+        "@types/node": "*"
+      }
+    },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
+    "ajv": {
+      "version": "6.7.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ajv/-/ajv-6.7.0.tgz",
+      "integrity": "sha1-4857s3LWV3uxg58d/fy/WtKUjZY=",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha1-fQHG+WFsmlGrD4xUmnnf5uwz76c="
+    },
+    "body-parser": {
+      "version": "1.18.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
+      }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha1-LR0kMXr7ir6V1tLAsHtXgTU52Cg=",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "dotenv": {
+      "version": "6.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha1-lBwEEFNdlCyL7PKNPzV9vZ1HYGQ="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "ejs": {
+      "version": "2.6.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ejs/-/ejs-2.6.1.tgz",
+      "integrity": "sha1-SY7A1JVlWrxvI81hho2SZGQHGqA="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha1-2m0NVpLvtGHggsFIF/4kJ9j10FQ="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "express": {
+      "version": "4.16.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/express/-/express-4.16.4.tgz",
+      "integrity": "sha1-/d72GSYQniTFFeqX/S8b2/Yt8S4=",
+      "requires": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha1-7r9O2EAHnIP0JJA4ydcDAIMBsQU=",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+        }
+      }
+    },
+    "follow-redirects": {
+      "version": "1.6.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/follow-redirects/-/follow-redirects-1.6.1.tgz",
+      "integrity": "sha1-UUlzxEtXVzaLrYvd/lL4HwFclMs=",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "gaxios": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/gaxios/-/gaxios-1.1.0.tgz",
+      "integrity": "sha1-paTlTE7vlYuSTsL8VM6bUaGeL5E=",
+      "requires": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^2.2.1",
+        "node-fetch": "^2.2.0"
+      }
+    },
+    "gcp-metadata": {
+      "version": "0.6.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
+      "integrity": "sha1-RVDAiFnFKLNwRZvXenGH6gvbxKs=",
+      "requires": {
+        "axios": "^0.18.0",
+        "extend": "^3.0.1",
+        "retry-axios": "0.3.2"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "google-auth-library": {
+      "version": "1.6.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/google-auth-library/-/google-auth-library-1.6.1.tgz",
+      "integrity": "sha1-nHPYMa1yDAwwSKuJ0P/exxTQfdI=",
+      "requires": {
+        "axios": "^0.18.0",
+        "gcp-metadata": "^0.6.3",
+        "gtoken": "^2.3.0",
+        "jws": "^3.1.5",
+        "lodash.isstring": "^4.0.1",
+        "lru-cache": "^4.1.3",
+        "retry-axios": "^0.3.2"
+      }
+    },
+    "google-p12-pem": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/google-p12-pem/-/google-p12-pem-1.0.3.tgz",
+      "integrity": "sha1-PYrMFAVzM5pbynsvaksga76m2Nc=",
+      "requires": {
+        "node-forge": "^0.7.5",
+        "pify": "^4.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
+        }
+      }
+    },
+    "googleapis": {
+      "version": "27.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/googleapis/-/googleapis-27.0.0.tgz",
+      "integrity": "sha1-whBjO0PnBHtl0z2kDEibbY+cArg=",
+      "requires": {
+        "google-auth-library": "^1.3.1",
+        "pify": "^3.0.0",
+        "qs": "^6.5.1",
+        "string-template": "1.0.0",
+        "uuid": "^3.2.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA="
+    },
+    "gtoken": {
+      "version": "2.3.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/gtoken/-/gtoken-2.3.2.tgz",
+      "integrity": "sha1-SYkKhmwfROFzCZvpVRXbWHKpIVE=",
+      "requires": {
+        "gaxios": "^1.0.4",
+        "google-p12-pem": "^1.0.0",
+        "jws": "^3.1.5",
+        "mime": "^2.2.0",
+        "pify": "^4.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/mime/-/mime-2.4.0.tgz",
+          "integrity": "sha1-4FH9iBNYWF8yed8zP+aU2gvP/dY="
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
+        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.8.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha1-hyQOdsmAjb3hh4PPImTvSSnuUOY=",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha1-gNEtBbKT0ehB58uLTmnlYa3Pg08=",
+      "requires": {
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
+    },
+    "mime-db": {
+      "version": "1.37.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha1-C2oM5v2+lXbiXx8tL96IMNwK0Ng="
+    },
+    "mime-types": {
+      "version": "2.1.21",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha1-KJlaoey3cHQv5q5+WPkYHHRLP5Y=",
+      "requires": {
+        "mime-db": "~1.37.0"
+      }
+    },
+    "moment": {
+      "version": "2.23.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/moment/-/moment-2.23.0.tgz",
+      "integrity": "sha1-dZ6kkayX1UusWtd2mW4qWMwbwiU="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha1-Gh2UC7+5FqHT4CGfA36J5x+MX6U="
+    },
+    "node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha1-/fO0GK7h+U8O9kLNY0hsd8qXJKw="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "plaid": {
+      "version": "2.10.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/plaid/-/plaid-2.10.0.tgz",
+      "integrity": "sha1-7HnSmZQzzjgZRoM79EwWeICsBBk=",
+      "requires": {
+        "@types/node": "9.x",
+        "@types/request": "0.0.36",
+        "bluebird": "^3.5.1",
+        "ramda": "0.23.x",
+        "request": "^2.74.0"
+      }
+    },
+    "proxy-addr": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha1-7PxzO/Iv+Mb0B/onUye5q2fki5M=",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.8.0"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "psl": {
+      "version": "1.1.31",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha1-6aqG0BAbWxBcvpOsa3hM1UcnYYQ="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+    },
+    "ramda": {
+      "version": "0.23.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ramda/-/ramda-0.23.0.tgz",
+      "integrity": "sha1-zNE//3NJepOXTj6GMnv9h71ujis="
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha1-GzJOzmtXBuFThVvBFIxlu39uoMM=",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/request/-/request-2.88.0.tgz",
+      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "retry-axios": {
+      "version": "0.3.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/retry-axios/-/retry-axios-0.3.2.tgz",
+      "integrity": "sha1-V1fID1hbTMTEmGqi/9R6YMbTXhM="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/send/-/send-0.16.2.tgz",
+      "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha1-CV6Ecv1bRiN9tQzkhqQ/S4bGzsE=",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
+    },
+    "sshpk": {
+      "version": "1.16.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/sshpk/-/sshpk-1.16.0.tgz",
+      "integrity": "sha1-HUljovv/5YBQqpCEyiC+gXQcB94=",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "string-template": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/string-template/-/string-template-1.0.0.tgz",
+      "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y="
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha1-+JzjQVQcZysl7nrjxz3uOyvlAZQ=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    }
+  }
+}

--- a/scripts/testSheets.js
+++ b/scripts/testSheets.js
@@ -4,5 +4,5 @@ const { updateSheet } = require('../lib/update')
 
 updateSheet([{
   range: 'A1',
-  value: 'It worked!'
+  values: [['It worked!']]
 }])


### PR DESCRIPTION
The default `updateSheet` function is a little limiting because you can only update one cell at a time. 

This was misleading to me because I tried to follow [some examples from the Google Sheet Docs](https://developers.google.com/sheets/api/samples/writing) and the values were getting clobbered – `updateSheet` wants a single value but I was trying to past in a list of lists as the Google Sheets API expects.

I think it'd be better if we allow a range of cells as an update, so that you can, for instance, write an entire **row** (i.e., a transaction) all at once. This PR enables that kind of write, and adds a basic example in the comments to map a list of transactions to a list of spreadsheet updates.